### PR TITLE
README: Fix license spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Still not working? Try this:
 Thanks to Surge1223 for precompiling ADB for the ARM/ARM64 architecture.
 
 # License
-While this project is GLPv3 licensed, I would like to add an additional parameter: no recompilations of the app are to be placed on the Google Play Store or any alternative APK-providing websites.
+While this project is GPLv3 licensed, I would like to add an additional parameter: no recompilations of the app are to be placed on the Google Play Store or any alternative APK-providing websites.
 
 Still confused? Email me at tylernij@gmail.com.


### PR DESCRIPTION
GLPv3 is not a license. Fix this spelling to GPLv3.