### PR TITLE
debug port upgrade for some devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          android:installLocation="internalOnly">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:installLocation="internalOnly">
 
     <uses-feature
         android:name="android.software.leanback"
@@ -24,18 +24,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-
-    <uses-permission
-        android:name="android.permission.NEARBY_WIFI_DEVICES"
-        android:usesPermissionFlags="neverForLocation" />
-
-
-    <supports-screens
-        android:largeScreens="true"
-        android:normalScreens="true"
-        android:smallScreens="false"
-        android:xlargeScreens="true"/>
 
     <application
         android:banner="@drawable/banner"
@@ -43,21 +31,9 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:allowBackup="true"
-        android:extractNativeLibs="true"
-        android:largeHeap="true"
-        android:fullBackupContent="true"
-        tools:ignore="GoogleAppIndexingWarning"
-
         android:theme="@style/Theme.LADB">
-        <meta-data
-            android:name="com.samsung.android.multiwindow.enable"
-            android:value="true" />
         <activity
             android:name=".views.MainActivity"
-            android:resizeableActivity="true"
-            android:launchMode="singleTask"
-            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,18 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation" />
+
+
+    <supports-screens
+        android:largeScreens="true"
+        android:normalScreens="true"
+        android:smallScreens="false"
+        android:xlargeScreens="true"/>
 
     <application
         android:banner="@drawable/banner"
@@ -31,9 +43,21 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:allowBackup="true"
+        android:extractNativeLibs="true"
+        android:largeHeap="true"
+        android:fullBackupContent="true"
+        tools:ignore="GoogleAppIndexingWarning"
+
         android:theme="@style/Theme.LADB">
+        <meta-data
+            android:name="com.samsung.android.multiwindow.enable"
+            android:value="true" />
         <activity
             android:name=".views.MainActivity"
+            android:resizeableActivity="true"
+            android:launchMode="singleTask"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app/src/main/java/com/draco/ladb/utils/ADB.kt
+++ b/app/src/main/java/com/draco/ladb/utils/ADB.kt
@@ -17,6 +17,7 @@ import java.io.File
 import java.io.PrintStream
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
+import androidx.core.content.edit
 
 class ADB(private val context: Context) {
     companion object {
@@ -61,6 +62,21 @@ class ADB(private val context: Context) {
      * Single shell instance where we can pipe commands to
      */
     private var shellProcess: Process? = null
+
+    private var manualDebugPort: String? = null
+    private var lastConnectedPort: String? = null
+    private val LAST_CONNECTED_PORT_KEY = "ladb_last_connected_port"
+
+    init {
+        // Load last connected port from shared preferences
+        lastConnectedPort = sharedPrefs.getString(LAST_CONNECTED_PORT_KEY, null)
+    }
+
+    fun setManualDebugPort(port: String) { manualDebugPort = port; lastConnectedPort = port }
+
+    private fun saveLastConnectedPort(port: String?) {
+        sharedPrefs.edit { putString(LAST_CONNECTED_PORT_KEY, port) }
+    }
 
     /**
      * Returns the user buffer size if valid, else the default
@@ -109,9 +125,9 @@ class ADB(private val context: Context) {
     /**
      * Start the ADB server
      */
-    fun initServer(): Boolean {
+    fun initServer(): InitResult {
         if (_running.value == true || tryingToPair)
-            return true
+            return InitResult.Success
 
         tryingToPair = true
 
@@ -120,11 +136,16 @@ class ADB(private val context: Context) {
         val secureSettingsGranted =
             context.checkSelfPermission(Manifest.permission.WRITE_SECURE_SETTINGS) == PackageManager.PERMISSION_GRANTED
 
+        var connectPort: String? = null
+
         if (autoShell) {
             /* Only do wireless debugging steps on compatible versions */
             if (secureSettingsGranted) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    cycleWirelessDebugging()
+                    if (lastConnectedPort == null) // No need to cycle when debugPort is known!
+                        cycleWirelessDebugging()
+                    else
+                        enableWirelessDebugging()
                 } else if (!isUSBDebuggingEnabled()) {
                     debug("Turning on USB debugging...")
                     Settings.Global.putInt(
@@ -166,24 +187,17 @@ class ADB(private val context: Context) {
             while (true) {
                 val nowTime = System.currentTimeMillis()
                 val pendingResolves = DnsDiscover.pendingResolves.get()
-
-                // Wait for pending DNS resolves to finish and the minimum scan time to elapse...
                 if (nowTime >= minDnsScanTime && !pendingResolves) {
                     debug("DNS resolver done...")
                     break
                 }
-
-                // Or if 10 seconds pass...
                 if (nowTime >= maxTimeoutTime) {
                     debug("DNS resolver took too long! Skipping...")
                     break
                 }
-
                 debug("Awaiting DNS resolver...")
-
                 Thread.sleep(1_000)
             }
-
             val adbPort = DnsDiscover.adbPort
             if (adbPort != null)
                 debug("Best ADB port discovered: $adbPort")
@@ -193,23 +207,42 @@ class ADB(private val context: Context) {
             debug("Starting ADB server...")
             adb(false, listOf("start-server")).waitFor(1, TimeUnit.MINUTES)
 
-            val waitProcess = if (adbPort != null)
-                adb(false, listOf("connect", "localhost:$adbPort")).waitFor(1, TimeUnit.MINUTES)
-            else
-                adb(false, listOf("wait-for-device")).waitFor(1, TimeUnit.MINUTES)
-
-            if (!waitProcess) {
-                debug("Your device didn't connect to LADB")
-                debug("If a reboot doesn't work, please contact support")
-
+            // Use lastConnectedPort if available, then discovered port, then manualDebugPort
+            connectPort = lastConnectedPort ?: adbPort?.toString() ?: manualDebugPort
+            if (connectPort == null) {
+                debug("No debug port found. Please enter the debug port (ADB connect port) shown in your device's Wireless Debugging screen.")
+                appendToOutput("[LADB] No debug port found. Please enter the debug port (ADB connect port) shown in your device's Wireless Debugging screen.")
                 tryingToPair = false
-                return false
+                return InitResult.NeedsPort
             }
+        }
+
+        return connectionAndStart(connectPort)
+    }
+
+    private fun connectionAndStart(connectPort: String?): InitResult {
+        val waitProcess =
+            adb(false, listOf("connect", "localhost:$connectPort")).waitFor(1, TimeUnit.MINUTES)
+
+        if (!waitProcess) {
+            debug("Your device didn't connect to LADB")
+            debug("If a reboot doesn't work, please contact support")
+
+            tryingToPair = false
+            return InitResult.Failure
         }
 
         val deviceList = getDevices()
         Log.d("DEVICES", "Devices: $deviceList")
 
+        if (deviceList.isEmpty()) {
+            debug("No devices found after connect. Please check your port and pairing code.")
+            lastConnectedPort = null
+            tryingToPair = false
+            return InitResult.NeedsPort
+        }
+
+        val autoShell = sharedPrefs.getBoolean(context.getString(R.string.auto_shell_key), true)
         shellProcess = if (autoShell) {
             var argList = listOf("shell")
 
@@ -256,6 +289,8 @@ class ADB(private val context: Context) {
 
         sendToShellProcess("alias adb=\"$adbPath\"")
 
+        val secureSettingsGranted =
+            context.checkSelfPermission(Manifest.permission.WRITE_SECURE_SETTINGS) == PackageManager.PERMISSION_GRANTED
         if (!secureSettingsGranted) {
             sendToShellProcess("pm grant ${BuildConfig.APPLICATION_ID} android.permission.WRITE_SECURE_SETTINGS &> /dev/null")
         }
@@ -270,10 +305,13 @@ class ADB(private val context: Context) {
         if (startupCommand.isNotEmpty())
             sendToShellProcess(startupCommand)
 
+        lastConnectedPort = connectPort
+        saveLastConnectedPort(connectPort)
+
         _running.postValue(true)
         tryingToPair = false
 
-        return true
+        return InitResult.Success
     }
 
     private fun isWirelessDebuggingEnabled() =
@@ -333,6 +371,24 @@ class ADB(private val context: Context) {
         }
     }
 
+    fun enableWirelessDebugging() {
+        val secureSettingsGranted =
+            context.checkSelfPermission(Manifest.permission.WRITE_SECURE_SETTINGS) == PackageManager.PERMISSION_GRANTED
+
+        if (secureSettingsGranted) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                if (!isWirelessDebuggingEnabled()) {
+                    Settings.Global.putInt(
+                        context.contentResolver,
+                        "adb_wifi_enabled",
+                        1
+                    )
+                    Thread.sleep(3_000)
+                }
+            }
+        }
+    }
+
     /**
      * Wait restart the shell once it dies
      */
@@ -374,7 +430,9 @@ class ADB(private val context: Context) {
         killShell.waitFor(3, TimeUnit.SECONDS)
         killShell.destroyForcibly()
 
-        return pairShell.exitValue() == 0
+        val success = pairShell.exitValue() == 0
+        debug("Pairing was " + if (success) "successful" else "unsuccessful")
+        return success
     }
 
     /**
@@ -429,5 +487,26 @@ class ADB(private val context: Context) {
             if (outputBufferFile.exists())
                 outputBufferFile.appendText("* $msg" + System.lineSeparator())
         }
+    }
+
+    /**
+     * Append a message to the output buffer (for user-visible output)
+     */
+    fun appendToOutput(msg: String) {
+        synchronized(outputBufferFile) {
+            if (outputBufferFile.exists())
+                outputBufferFile.appendText(msg + System.lineSeparator())
+        }
+    }
+
+    fun resumeInitServerWithPort(port: String): InitResult {
+        manualDebugPort = port
+        return connectionAndStart(port)
+    }
+
+    sealed class InitResult {
+        object Success : InitResult()
+        object NeedsPort : InitResult()
+        object Failure : InitResult()
     }
 }

--- a/app/src/main/java/com/draco/ladb/utils/ADB.kt
+++ b/app/src/main/java/com/draco/ladb/utils/ADB.kt
@@ -23,6 +23,7 @@ class ADB(private val context: Context) {
     companion object {
         const val MAX_OUTPUT_BUFFER_SIZE = 1024 * 16
         const val OUTPUT_BUFFER_DELAY_MS = 100L
+        const val LAST_CONNECTED_PORT_KEY = "ladb_last_connected_port"
 
         @SuppressLint("StaticFieldLeak")
         @Volatile
@@ -65,7 +66,6 @@ class ADB(private val context: Context) {
 
     private var manualDebugPort: String? = null
     private var lastConnectedPort: String? = null
-    private val LAST_CONNECTED_PORT_KEY = "ladb_last_connected_port"
 
     init {
         // Load last connected port from shared preferences

--- a/app/src/main/java/com/draco/ladb/utils/DnsDiscover.kt
+++ b/app/src/main/java/com/draco/ladb/utils/DnsDiscover.kt
@@ -53,19 +53,7 @@ class DnsDiscover private constructor(
         )
 
         serviceTypes.forEach { type ->
-            val listener = object : NsdManager.DiscoveryListener {
-                override fun onDiscoveryStarted(serviceType: String) {
-                    Log.d("DnsDiscover", "Discovery started for $serviceType")
-                }
-
-                override fun onServiceFound(serviceInfo: NsdServiceInfo) {}
-                override fun onServiceLost(serviceInfo: NsdServiceInfo) {}
-                override fun onDiscoveryStopped(serviceType: String) {}
-                override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {}
-                override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {}
-            }
-
-            nsdManager.discoverServices(type, NsdManager.PROTOCOL_DNS_SD, listener)
+            nsdManager.discoverServices(type, NsdManager.PROTOCOL_DNS_SD, discoveryListener())
         }
     }
 
@@ -238,7 +226,7 @@ class DnsDiscover private constructor(
         nsdManager.resolveService(service, resolveListener)
     }
 
-    val discoveryListener = object : NsdManager.DiscoveryListener {
+    fun discoveryListener() = object : NsdManager.DiscoveryListener {
         override fun onDiscoveryStarted(regType: String) {
             Log.d(TAG, "Service discovery started")
         }

--- a/app/src/main/java/com/draco/ladb/utils/DnsDiscover.kt
+++ b/app/src/main/java/com/draco/ladb/utils/DnsDiscover.kt
@@ -46,11 +46,27 @@ class DnsDiscover private constructor(
         }
         started = true
         aliveTime = System.currentTimeMillis()
-        nsdManager.discoverServices(
-            "_adb-tls-connect._tcp",
-            NsdManager.PROTOCOL_DNS_SD,
-            discoveryListener
+
+        val serviceTypes = listOf(
+            "_adb-tls-pairing._tcp.",
+            "_adb-tls-connect._tcp."
         )
+
+        serviceTypes.forEach { type ->
+            val listener = object : NsdManager.DiscoveryListener {
+                override fun onDiscoveryStarted(serviceType: String) {
+                    Log.d("DnsDiscover", "Discovery started for $serviceType")
+                }
+
+                override fun onServiceFound(serviceInfo: NsdServiceInfo) {}
+                override fun onServiceLost(serviceInfo: NsdServiceInfo) {}
+                override fun onDiscoveryStopped(serviceType: String) {}
+                override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {}
+                override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {}
+            }
+
+            nsdManager.discoverServices(type, NsdManager.PROTOCOL_DNS_SD, listener)
+        }
     }
 
     /**

--- a/app/src/main/java/com/draco/ladb/viewmodels/MainActivityViewModel.kt
+++ b/app/src/main/java/com/draco/ladb/viewmodels/MainActivityViewModel.kt
@@ -42,23 +42,54 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
     private val _viewModelHasStartedADB = MutableLiveData(false)
     val viewModelHasStartedADB: LiveData<Boolean> = _viewModelHasStartedADB
 
+    private val _needsDebugPort = MutableLiveData<Boolean>()
+    val needsDebugPort: LiveData<Boolean> = _needsDebugPort
+
     init {
         startOutputThread()
         dnsDiscover.scanAdbPorts()
     }
 
-
-    fun startADBServer(callback: ((Boolean) -> (Unit))? = null) {
+    fun startADBServer() {
         // Don't start if it's already started.
         if (_viewModelHasStartedADB.value == true || adb.running.value == true) return
 
         viewModelScope.launch(Dispatchers.IO) {
-            val success = adb.initServer()
-            if (success) {
-                startShellDeathThread()
-                _viewModelHasStartedADB.postValue(true)
+            when (adb.initServer()) {
+                is ADB.InitResult.Success -> {
+                    startShellDeathThread()
+                    adb.appendToOutput("Start ADB Success!")
+                    _viewModelHasStartedADB.postValue(true)
+                }
+                is ADB.InitResult.NeedsPort -> {
+                    adb.appendToOutput("Needs debug port manually.")
+                    _needsDebugPort.postValue(true)
+                }
+                is ADB.InitResult.Failure -> {
+                    adb.appendToOutput("Failed to Start ADB!")
+                }
             }
-            callback?.invoke(success)
+        }
+    }
+
+    fun resumeADBServerWithPort(port: String, callback: ((Boolean) -> (Unit))? = null) {
+        viewModelScope.launch(Dispatchers.IO) {
+            when (adb.resumeInitServerWithPort(port)) {
+                is ADB.InitResult.Success -> {
+                    startShellDeathThread()
+                    _viewModelHasStartedADB.postValue(true)
+                    _needsDebugPort.postValue(false)
+                    callback?.invoke(true)
+                }
+                is ADB.InitResult.Failure -> {
+                    _needsDebugPort.postValue(false)
+                    callback?.invoke(false)
+                }
+                else -> {
+                    _needsDebugPort.postValue(false)
+                    callback?.invoke(false)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/draco/ladb/viewmodels/MainActivityViewModel.kt
+++ b/app/src/main/java/com/draco/ladb/viewmodels/MainActivityViewModel.kt
@@ -60,6 +60,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
                     startShellDeathThread()
                     adb.appendToOutput("Start ADB Success!")
                     _viewModelHasStartedADB.postValue(true)
+                    _needsDebugPort.postValue(false)
                 }
                 is ADB.InitResult.NeedsPort -> {
                     adb.appendToOutput("Needs debug port manually.")
@@ -72,22 +73,19 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
         }
     }
 
-    fun resumeADBServerWithPort(port: String, callback: ((Boolean) -> (Unit))? = null) {
+    fun resumeADBServerWithPort(port: String) {
         viewModelScope.launch(Dispatchers.IO) {
             when (adb.resumeInitServerWithPort(port)) {
                 is ADB.InitResult.Success -> {
                     startShellDeathThread()
                     _viewModelHasStartedADB.postValue(true)
                     _needsDebugPort.postValue(false)
-                    callback?.invoke(true)
                 }
                 is ADB.InitResult.Failure -> {
                     _needsDebugPort.postValue(false)
-                    callback?.invoke(false)
                 }
                 else -> {
                     _needsDebugPort.postValue(false)
-                    callback?.invoke(false)
                 }
             }
         }

--- a/app/src/main/java/com/draco/ladb/views/MainActivity.kt
+++ b/app/src/main/java/com/draco/ladb/views/MainActivity.kt
@@ -1,11 +1,8 @@
 package com.draco.ladb.views
 
-import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
-import android.provider.Settings
 import android.view.*
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
@@ -15,8 +12,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.edit
 import androidx.core.view.ViewCompat
@@ -36,7 +31,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlin.system.exitProcess
 import androidx.core.net.toUri
-import java.io.BufferedReader
+
 
 class MainActivity : AppCompatActivity() {
     private val viewModel: MainActivityViewModel by viewModels()
@@ -50,45 +45,6 @@ class MainActivity : AppCompatActivity() {
         val text = it.data?.getStringExtra(Intent.EXTRA_TEXT) ?: return@registerForActivityResult
         binding.command.setText(text)
     }
-
-    /*override fun onResume() {
-        super.onResume()
-        if (!Settings.canDrawOverlays(baseContext)) {
-            val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                ("package:" + baseContext.packageName).toUri())
-            baseContext.startActivity(intent)
-        }
-
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.NEARBY_WIFI_DEVICES)
-            != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(
-                this, arrayOf(Manifest.permission.NEARBY_WIFI_DEVICES), 1001)
-        }
-
-        if (ContextCompat.checkSelfPermission(
-                baseContext,
-                Manifest.permission.ACCESS_FINE_LOCATION
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
-            ActivityCompat.requestPermissions(
-                this,
-                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
-                13
-            )
-        }
-
-        if (ContextCompat.checkSelfPermission(
-                baseContext,
-                Manifest.permission.ACCESS_COARSE_LOCATION
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
-            ActivityCompat.requestPermissions(
-                this,
-                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
-                14
-            )
-        }
-    }*/
 
     private fun setupUI() {
         /* Fix stupid Google edge-to-edge bullshit */
@@ -214,9 +170,9 @@ class MainActivity : AppCompatActivity() {
         // Observe needsDebugPort and prompt user if needed
         viewModel.needsDebugPort.observe(this) { needsPort ->
             if (needsPort == true) {
-                val debugPortInput = com.google.android.material.textfield.TextInputEditText(this)
+                val debugPortInput = TextInputEditText(this)
                 debugPortInput.inputType = android.text.InputType.TYPE_CLASS_NUMBER
-                val dialog = androidx.appcompat.app.AlertDialog.Builder(this)
+                val dialog = AlertDialog.Builder(this)
                     .setTitle("Enter Debug Port")
                     .setMessage("Enter the debug port (not the pairing port) shown in your device's Wireless Debugging screen.")
                     .setView(debugPortInput)
@@ -271,7 +227,8 @@ class MainActivity : AppCompatActivity() {
                     }
 
                     getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener {
-                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.tutorial_url)))
+                        val intent = Intent(Intent.ACTION_VIEW,
+                            getString(R.string.tutorial_url).toUri())
                         try {
                             startActivity(intent)
                         } catch (e: Exception) {

--- a/app/src/main/res/layout/dialog_pair.xml
+++ b/app/src/main/res/layout/dialog_pair.xml
@@ -2,6 +2,7 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:padding="16dp">
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
At some Android devices, the debug port can't be automatically found. 
With this update, a user dialog will shown when the debug port is not exist. Also wireless open/close cycle not required for these devices. It will bypass the cycle.