### PR TITLE
feature: Add persistent notification for wireless pairing (Fixes non-split-screen pairing)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,10 @@
         android:required="false"/>
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <uses-permission
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions"/>
@@ -59,6 +63,14 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE"/>
             </intent-filter>
         </service>
+
+        <service
+            android:name=".services.PairingService"
+            android:foregroundServiceType="connectedDevice" />
+
+        <receiver
+            android:name=".receivers.PairingReceiver"
+            android:exported="true" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/draco/ladb/receivers/PairingReceiver.kt
+++ b/app/src/main/java/com/draco/ladb/receivers/PairingReceiver.kt
@@ -1,0 +1,188 @@
+package com.draco.ladb.receivers
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import androidx.core.app.RemoteInput
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.preference.PreferenceManager
+import com.draco.ladb.R
+import com.draco.ladb.services.PairingService
+import com.draco.ladb.utils.ADB
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import android.net.nsd.NsdManager
+import com.draco.ladb.utils.DnsDiscover
+
+class PairingReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val nsdManager = context.getSystemService(Context.NSD_SERVICE) as NsdManager
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+
+        if (intent.action == ACTION_RETRY) {
+            prefs.edit().remove(PREF_PENDING_PORT).apply()
+            updateNotification(context, notificationManager, "Enter Port", true, "Enter Port")
+            return
+        }
+
+        val results = RemoteInput.getResultsFromIntent(intent) ?: return
+        
+        DnsDiscover.getInstance(context, nsdManager).scanAdbPorts()
+        
+        val adb = ADB.getInstance(context)
+        val coroutineScope = CoroutineScope(Dispatchers.IO)
+
+        val rawInput = results.getCharSequence(REMOTE_INPUT_KEY).toString().trim()
+        Log.d("LADB_Pairing", "Input received: '$rawInput'")
+
+        val parts = rawInput.split(Regex("\\s+"))
+        
+        var port: String? = null
+        var code: String? = null
+
+        if (parts.size >= 2) {
+            port = parsePort(parts[0])
+            code = parts[1]
+        } else if (parts.size == 1) {
+            val input = parts[0]
+            val pendingPort = prefs.getString(PREF_PENDING_PORT, null)
+
+            if (input.contains(":")) {
+                val parsedPort = parsePort(input)
+                if (parsedPort != null) {
+                    prefs.edit().putString(PREF_PENDING_PORT, parsedPort).apply()
+                    updateNotification(context, notificationManager, "Port $parsedPort saved. Enter Pairing Code:", true, "Enter Code")
+                    return
+                }
+            } else if (pendingPort != null) {
+                port = pendingPort
+                code = input
+                prefs.edit().remove(PREF_PENDING_PORT).apply()
+            } else {
+                val parsedPort = parsePort(input)
+                if (parsedPort != null && (parsedPort.toIntOrNull() ?: 70000) <= 65535) {
+                    prefs.edit().putString(PREF_PENDING_PORT, parsedPort).apply()
+                    updateNotification(context, notificationManager, "Port $parsedPort saved. Enter Pairing Code:", true, "Enter Code")
+                    return
+                } else {
+                     updateNotification(context, notificationManager, "Invalid Port. Enter Port:", true, "Enter Port")
+                     return
+                }
+            }
+        }
+
+        if (port != null && code != null) {
+            coroutineScope.launch {
+                try {
+                    updateNotification(context, notificationManager, "Pairing $port with $code...", false, "")
+                    
+                    val output = adb.pair(port, code)
+                    Log.d("LADB_Pairing", "Output: $output")
+                    
+                    val isSuccess = output.contains("Successfully paired", ignoreCase = true)
+                    
+                    if (isSuccess) {
+                        updateNotification(context, notificationManager, "Success! Connecting...", false, "")
+                        val serverStarted = adb.initServer()
+                        if (serverStarted) {
+                             updateNotification(context, notificationManager, "Connected! You can now use LADB.", false, "")
+                        } else {
+                             showErrorNotification(context, notificationManager, "Paired, but connection failed.")
+                        }
+                    } else {
+                        val displayLog = if (output.length > 100) output.take(100) + "..." else output
+                        showErrorNotification(context, notificationManager, "Failed: $displayLog")
+                    }
+                } catch (e: Exception) {
+                    Log.e("LADB_Pairing", "Exception during pair", e)
+                    showErrorNotification(context, notificationManager, "Error: ${e.message}")
+                }
+            }
+        } else {
+            updateNotification(context, notificationManager, "Invalid input. Need Port + Code.", true, "Enter Port")
+        }
+    }
+
+    private fun showErrorNotification(context: Context, manager: NotificationManager, text: String) {
+        val intent = Intent(context, PairingReceiver::class.java).apply {
+            action = ACTION_RETRY
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val action = NotificationCompat.Action.Builder(
+            R.drawable.ic_baseline_restore_24dp,
+            "Retry",
+            pendingIntent
+        ).build()
+
+        val notification = NotificationCompat.Builder(context, PairingService.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_baseline_adb_24)
+            .setContentTitle("Wireless Pairing")
+            .setContentText(text)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .addAction(action)
+            .build()
+
+        manager.notify(PairingService.NOTIFICATION_ID, notification)
+    }
+
+    private fun parsePort(input: String): String? {
+        val portStr = if (input.contains(":")) {
+            input.substringAfterLast(":")
+        } else {
+            input
+        }
+        return if (portStr.toIntOrNull() != null) portStr else null
+    }
+
+    private fun updateNotification(context: Context, manager: NotificationManager, text: String, showAction: Boolean, inputLabel: String) {
+        val builder = NotificationCompat.Builder(context, PairingService.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_baseline_adb_24)
+            .setContentTitle("Wireless Pairing")
+            .setContentText(text)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+
+        if (showAction) {
+            val remoteInput = RemoteInput.Builder(REMOTE_INPUT_KEY).run {
+                setLabel(inputLabel)
+                build()
+            }
+
+            val intent = Intent(context, PairingReceiver::class.java)
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+
+            val action = NotificationCompat.Action.Builder(
+                R.drawable.ic_baseline_adb_24,
+                "Enter",
+                pendingIntent
+            ).addRemoteInput(remoteInput).build()
+            
+            builder.addAction(action)
+        }
+
+        manager.notify(PairingService.NOTIFICATION_ID, builder.build())
+    }
+
+    companion object {
+        const val REMOTE_INPUT_KEY = "pairing_input"
+        const val PREF_PENDING_PORT = "pending_pairing_port"
+        const val ACTION_RETRY = "com.draco.ladb.ACTION_RETRY"
+    }
+}

--- a/app/src/main/java/com/draco/ladb/services/PairingService.kt
+++ b/app/src/main/java/com/draco/ladb/services/PairingService.kt
@@ -1,0 +1,77 @@
+package com.draco.ladb.services
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.RemoteInput
+import com.draco.ladb.R
+import com.draco.ladb.receivers.PairingReceiver
+
+class PairingService : Service() {
+    private lateinit var notificationManager: NotificationManager
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        android.widget.Toast.makeText(this, "Starting Pairing Service...", android.widget.Toast.LENGTH_SHORT).show()
+        notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        createNotificationChannel()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(NOTIFICATION_ID, createNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE)
+        } else {
+            startForeground(NOTIFICATION_ID, createNotification())
+        }
+        return START_STICKY
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Pairing",
+            NotificationManager.IMPORTANCE_HIGH
+        )
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    private fun createNotification(): android.app.Notification {
+        val remoteInput = RemoteInput.Builder(PairingReceiver.REMOTE_INPUT_KEY).run {
+            setLabel("Enter Port")
+            build()
+        }
+
+        val intent = Intent(this, PairingReceiver::class.java)
+        val pendingIntent = PendingIntent.getBroadcast(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_MUTABLE
+        )
+
+        val action = NotificationCompat.Action.Builder(
+            R.drawable.ic_baseline_adb_24,
+            "Enter",
+            pendingIntent
+        ).addRemoteInput(remoteInput).build()
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_baseline_adb_24)
+            .setContentTitle("Wireless Pairing")
+            .setContentText("Enter Port")
+            .setOngoing(true)
+            .addAction(action)
+            .build()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    companion object {
+        const val CHANNEL_ID = "pairing_channel_v2"
+        const val NOTIFICATION_ID = 1
+    }
+}

--- a/app/src/main/java/com/draco/ladb/utils/ADB.kt
+++ b/app/src/main/java/com/draco/ladb/utils/ADB.kt
@@ -385,11 +385,11 @@ class ADB(private val context: Context) {
     /**
      * Ask the device to pair on Android 11+ devices
      */
-    fun pair(port: String, pairingCode: String): Boolean {
+    fun pair(port: String, pairingCode: String): String {
         val pairShell = adb(false, listOf("pair", "localhost:$port"))
 
         /* Sleep to allow shell to catch up */
-        Thread.sleep(5000)
+        Thread.sleep(1000)
 
         /* Pipe pairing code */
         PrintStream(pairShell.outputStream).apply {
@@ -398,14 +398,21 @@ class ADB(private val context: Context) {
         }
 
         /* Continue once finished pairing (or 10s elapses) */
-        pairShell.waitFor(10, TimeUnit.SECONDS)
-        pairShell.destroyForcibly().waitFor()
+        val exited = pairShell.waitFor(10, TimeUnit.SECONDS)
 
-        val killShell = adb(false, listOf("kill-server"))
-        killShell.waitFor(3, TimeUnit.SECONDS)
-        killShell.destroyForcibly()
+        val output = try {
+            val stdout = pairShell.inputStream.bufferedReader().use { it.readText() }
+            val stderr = pairShell.errorStream.bufferedReader().use { it.readText() }
+            if (stdout.isNotBlank()) stdout else stderr
+        } catch (e: Exception) {
+            "Error reading output: ${e.message}"
+        }
 
-        return pairShell.exitValue() == 0
+        if (!exited) {
+            pairShell.destroyForcibly()
+        }
+
+        return output.trim()
     }
 
     /**

--- a/app/src/main/java/com/draco/ladb/views/MainActivity.kt
+++ b/app/src/main/java/com/draco/ladb/views/MainActivity.kt
@@ -189,7 +189,11 @@ class MainActivity : AppCompatActivity() {
 
                         lifecycleScope.launch(Dispatchers.IO) {
                             viewModel.adb.debug("Trying to pair...")
-                            val success = viewModel.adb.pair(port, code)
+                            val output = viewModel.adb.pair(port, code)
+                            val success = output.contains("Successfully paired")
+                            if (!success) {
+                                viewModel.adb.debug("Pairing failed output: $output")
+                            }
                             callback?.invoke(success)
                         }
                     }
@@ -223,6 +227,21 @@ class MainActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
+            R.id.pair_notification -> {
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                    if (checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                        requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), 101)
+                    } else {
+                        val intent = Intent(this, com.draco.ladb.services.PairingService::class.java)
+                        startService(intent)
+                    }
+                } else {
+                    val intent = Intent(this, com.draco.ladb.services.PairingService::class.java)
+                    startService(intent)
+                }
+                true
+            }
+
             R.id.bookmarks -> {
                 val intent = Intent(this, BookmarksActivity::class.java)
                     .putExtra(Intent.EXTRA_TEXT, binding.command.text.toString())
@@ -269,6 +288,18 @@ class MainActivity : AppCompatActivity() {
             }
 
             else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == 101) {
+            if (grantResults.isNotEmpty() && grantResults[0] == android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                val intent = Intent(this, com.draco.ladb.services.PairingService::class.java)
+                startService(intent)
+            } else {
+                Snackbar.make(binding.root, "Permission denied", Snackbar.LENGTH_SHORT).show()
+            }
         }
     }
 

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -2,6 +2,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/pair_notification"
+        android:title="@string/pairing_notification"
+        app:showAsAction="never"
+        android:icon="@drawable/ic_baseline_portable_wifi_off_24" />
+    <item
         android:id="@+id/bookmarks"
         android:title="@string/bookmarks"
         app:showAsAction="ifRoom"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="command_hint">Shell command</string>
     <string name="command_hint_waiting">Waiting for connection…</string>
 
+    <string name="pairing_notification">Pairing Notification</string>
     <string name="bookmarks">Bookmarks</string>
     <string name="last_command">Last command</string>
     <string name="help">Help</string>


### PR DESCRIPTION
This PR addresses a major UX barrier for devices that do not support split-screen or floating windows.

This new feature allows the user to complete the entire pairing and connection process directly from the notification shade while the Developer Options screen remains open in the foreground.

# Key Features

* Two-Step Stateful Pairing:
* Step 1: User inputs the Port (or IP:Port) via the notification.
* Step 2: The notification updates to ask for the Pairing Code.


* The app statefully remembers the port between steps, providing a clean, conversational flow.
* Real-time Feedback: Displays actual output logs from the ADB command in the notification text (e.g., "Successfully paired" or real error messages like "Wrong password").
* Automatic Connection: Immediately triggers mDNS discovery and initServer() upon successful pairing, ensuring the app is connected and ready to use as soon as the user returns to it.
* Dynamic UI: The input field and "Enter" button automatically disappear once the status reaches "Connected!", leaving a clean confirmation message.
* Retry Mechanism: If pairing fails, a "Retry" action button appears to reset the flow without needing to reopen the app.

# Sample Testing

<details>
<summary><b>View Screenshots</b></summary>

1. Open the LADB app

<img width="250" height="1600" alt="1" src="https://github.com/user-attachments/assets/599b8d4a-4e7a-4a6f-863d-de0b69440b96" />

2. Select "Pairing Notification" from the menu.

<img width="250" height="1600" alt="2" src="https://github.com/user-attachments/assets/049e0905-54cc-49e1-8d1d-1bf0830f5840" />


Allow it.

<img width="250" height="1600" alt="3" src="https://github.com/user-attachments/assets/ddcb175d-424c-4bb7-8b4b-8db7fc2f4c7e" />


3. Navigate to Developer Options > Wireless Debugging > Pair with pairing code.

<img width="250" height="1600" alt="4" src="https://github.com/user-attachments/assets/d46ab9d6-ee7a-4c06-8c4f-f7132383bf9e" />

4. Expand the LADB notification.
5. Enter the Port -> Tap Enter.

<img width="250" height="1600" alt="5" src="https://github.com/user-attachments/assets/df31cd14-9616-4f46-8500-fca89fe881ac" />

6. Enter the Code -> Tap Enter.

<img width="250" height="1600" alt="image" src="https://github.com/user-attachments/assets/936436e8-9b50-4322-a408-bb99ac84e7aa" />

7. Verify the notification says "Connected! You can now use LADB." and the input field hides.
<img width="250" height="1600" alt="image" src="https://github.com/user-attachments/assets/42fe2121-9911-45fa-8ae8-acc0eaa26458" />

<img width="250" height="1600" alt="image" src="https://github.com/user-attachments/assets/4441d014-49e6-4d58-bbfa-2526c66c8fc3" />

8. Return to LADB and verify the shell is active.

<img width="250" height="1600" alt="image" src="https://github.com/user-attachments/assets/b17f4b2a-f2ee-4683-836e-47f41e38307b" />

</details>